### PR TITLE
Do not fork word-count repo, instead generate from a template

### DIFF
--- a/_episodes/04-sphinx.md
+++ b/_episodes/04-sphinx.md
@@ -335,57 +335,6 @@ This is useful to check how things look before pushing changes to GitHub or else
 > ```
 {: .task}
 
-> ## Exercise: Update existing documentation that is not yours (Optional)
-> 
-> Very often we are using existing software/packages that have their own documentation in [ReadTheDocs](https://readthedocs.org/).
-> It is good practice to participate in improving the documentation, especially when spotting problems or areas 
-> that needs to be clarified.
-> The goal of this exercise is to update/improve an [existing documentation](https://word-count.readthedocs.io/en/latest/) 
-> available on [ReadTheDocs](https://readthedocs.org/).
-> ### Take a few minutes to read it and before you start
->
-> - Discuss the exercise idea with the classroom.
-> - Distribute exercises among groups of 2-3 persons.
-> - Open a GitHub issue and inform the community about the problem and how you
->  plan to solve it. Discuss why we do this.
-> - Fork this project.
-> - Commit to your fork. In your commit message auto-close the issue you have addressed.
-> - Submit a pull request.
-> - We then review the pull requests.
-> - After the pull requests are merged we verify that documentation updates itself.
->
->
-> ### Basic
->
-> - Document the purpose of this example code.
-> - Document how to clone the code.
-> - Describe the project tree structure.
-> - Write a sentence or two about Zipf's law and link to Wikipedia
->   (coordinate with the group working on the previous exercise).
-> - Document how to check the code style with ``pycodestyle``.
-> - Give other developers hints on how they can contribute to the documentation.
-> - Document how to build the documentation locally
->   (coordinate with the group working on the previous exercise).
-> - Add an example output.
-> - Add an example plot
->   (coordinate with the group working on the previous exercise).
-> - Document where/how to ask for help.
-> - Add a math equation somewhere.
-> 
-> 
-> ### Advanced
-> 
-> - Add a test and document how to run it.
-> - Add the possibility to auto-document Python code.
-> 
-> 
-> ### Meta
-> 
-> - Add new exercises ideas for future workshops (edit this file).
->
-{: .task}
-
-
 > ## Rendering (LaTeX) math equations
 >
 > There are two different ways to display mathematical equations within Sphinx: `pngmath`and `MathJax`. 

--- a/_episodes/05-rtd.md
+++ b/_episodes/05-rtd.md
@@ -46,7 +46,7 @@ objectives:
 >     - The project contains a script for counting the frequency distribution of words in a given file and some documentation generated using sphinx. For bigger projects, we will have much more source files.
 > 2. In the second step, enable the project on Read the Docs.
 > 
-> ### Step 1: Copy the [word-count project template](https://github.com/coderefinery/word-count/generate) to your namespace and clone the repository
+> ### Step 1: Go to the [word-count project template](https://github.com/coderefinery/word-count/generate), copy it to your namespace, and clone the repository
 > 
 > - The repository contains following two folders, among few other files and folder. 
 >     - **source** folder contains the source code

--- a/_episodes/05-rtd.md
+++ b/_episodes/05-rtd.md
@@ -35,18 +35,18 @@ objectives:
 
 > ## Exercise: Deploy Sphinx documentation to Read the Docs
 > 
-> In this exercise we will fork an example repository on GitHub and deploy it to Read the Docs.
+> In this exercise we will make a copy of an example repository on GitHub and deploy it to Read the Docs.
 > 
 > We will use GitHub for this exercise but it will also work with any Git
 > repository with public read access.
 > 
-> 1. In the first step, fork 
->  [this word-count example project](https://github.com/coderefinery/word-count.git) and
->  then clone the fork to your laptop
+> 1. In the first step, generate a new repository based on
+>  [this word-count example project template](https://github.com/coderefinery/word-count/generate) and
+>  then clone the newly created repository to your laptop.
 >     - The project contains a script for counting the frequency distribution of words in a given file and some documentation generated using sphinx. For bigger projects, we will have much more source files.
-> 2. In the second step, enable the project on Read the Docs
+> 2. In the second step, enable the project on Read the Docs.
 > 
-> ### Step 1: Fork the [word-count project](https://github.com/coderefinery/word-count.git) and clone the repository
+> ### Step 1: Copy the [word-count project template](https://github.com/coderefinery/word-count/generate) to your namespace and clone the repository
 > 
 > - The repository contains following two folders, among few other files and folder. 
 >     - **source** folder contains the source code
@@ -102,12 +102,6 @@ objectives:
 > not necessary to add it. The documentation will be automatically generated.
 >
 {: .callout}
-
-> ## (Optional) Create a pull request to the central repository
-> 
-> It might be fun to collect the documentation contributions from everyone into the same 
-> central repository.
-{: .task}
 
 > ## Running your own sphinx server
 >


### PR DESCRIPTION
In my opinion the generation from a template is nicer than searching for the importer and manually filling it out.

One controversial change can be the removal of my own exercise (fix the central repo by sending PRs), but I have now seen a couple of workshops where this lesson went overtime and we have not even attempted that exercise.

I think this exercise is cleaner without a fork relation. It is also easier for us since we don't have to clean up and set up anything for future workshops.