### PR TITLE
Correct Sphinx syntax for cross-referencing

### DIFF
--- a/_episodes/04-sphinx.md
+++ b/_episodes/04-sphinx.md
@@ -360,7 +360,7 @@ Note that you can change the styling by editing `conf.py` and changing the value
 >    \end{eqnarray}
 > ```
 >
-> These equations can then be referenced using `:eq: myequation` and `:eq: myarray`.
+> These equations can then be referenced using ``:eq:`myequation` `` and ``:eq:`myarray` ``.
 >
 {: .callout}
 


### PR DESCRIPTION
Cross-referencing role in Sphinx (:eq:) uses syntax :eq:`label` and not :eq: label,
see https://shimizukawa-sphinx.readthedocs.io/en/latest/ext/math.html#role-eq.