### PR TITLE
Fix typo inside a command

### DIFF
--- a/_episodes/05-rtd.md
+++ b/_episodes/05-rtd.md
@@ -72,7 +72,7 @@ objectives:
 >
 > Inside the cloned repository, check the integrity of all external links:
 >```
->$ sphinx-build doc -W -blinkcheck -d _build/doctrees _build/html
+>$ sphinx-build doc -W -b linkcheck -d _build/doctrees _build/html
 >```
 >
 > ### Step 2: Enable the project on [Read the Docs](https://readthedocs.org)


### PR DESCRIPTION
According to the [builder documentation](https://www.sphinx-doc.org/en/master/man/sphinx-build.html?highlight=-b+buildername) there should be a space there. Strangely enough the command seems to work without it as well ¯\\_(ツ)_/¯ 