### PR TITLE
Add more items to the documentation checklist

### DIFF
--- a/_episodes/01-wishlist.md
+++ b/_episodes/01-wishlist.md
@@ -158,6 +158,8 @@ or verbally), please do!
 > - Copy-paste-able example to get started
 > - Dependencies and their versions or version ranges
 > - Installation instructions
+> - Tutorials covering key functionality
+> - Reference documentation (e.g. API) covering all functionality
 > - How do you want to be asked questions (mailing list or forum or chat or issue tracker)
 > - Possibly a FAQ section
 > - Contribution guide


### PR DESCRIPTION
The documentation checklist does a great job of covering all the things I would include in a `README` file, but what about the documentation other than the `README`? I tried to capture this aspect in two bullet points:

 - Tutorials covering key functionality   `# by which I mean the main narrative documentation`
 - Reference documentation (e.g. API) covering all functionality

Not every project needs such detailed docs of course, which is why at the top of the list we mention that not all bullet points need to be present, it depends on the size (number of users) of the project.