### PR TITLE
Add MNE-Python as documentation example

### DIFF
--- a/_episodes/01-wishlist.md
+++ b/_episodes/01-wishlist.md
@@ -42,11 +42,11 @@ to point at others.
 Instead we list some of the projects we have contributed to (possibly long time
 ago), with varying quality of documentation:
 
-- [pcd](https://github.com/rkdarst/pcd)
 - [Dalton](https://daltonprogram.org/documentation/) (check the PDF
   manuals, e.g. [Dalton 2018](https://daltonprogram.org/manuals/dalton2018manual.pdf))
 - [Cubicle](https://github.com/bast/cubicle)
 - [Numgrid](https://github.com/dftlibs/numgrid)
+- [MNE-Python](https://mne.tools)
 
 Discuss in groups what you like / or don't like about each before discussing it
 as a class.

--- a/guide.md
+++ b/guide.md
@@ -178,12 +178,8 @@ break if you need more time to fix problems.
 
 Here we mention few of our own examples: <https://coderefinery.github.io/documentation/01-wishlist/#own-examples>
 
-These are some of the problems (which hopefully crystallize in a discussion):
+These are some of the successes and problems (which hopefully crystallize in a discussion):
 
-- pcd:
-  - no README
-  - no usage examples
-  - one has to go into the source code to find out how to use it
 - Dalton:
   - try to copy paste input snippets from the PDF
   - manual is generated manually by running LaTeX, so in practice it is often behind
@@ -193,6 +189,11 @@ These are some of the problems (which hopefully crystallize in a discussion):
 - Numgrid:
   - contains copy-paste-able examples
   - contains recommended citation
+  - no tutorials with clear narration
+- MNE-Python:
+  - easy to select version of docs
+  - has four "levels": tutorials, how-to guides (examples), explanation pages and API reference
+  - this level of documentation is overkill for small projects, but serves as a great source of ideas
 
 
 ### Live better than reading the website material


### PR DESCRIPTION
Since we will teach how to host Sphynx documentation it would be nice to include an example of a project that actually does this. MNE-Python also contains all 4 types of documentation mentioned in "What nobody tells you about documentation".

This is an example of what documentation could be if you apply every technique we mention in this lesson.