### PR TITLE
Update 06-gh-pages.md

### DIFF
--- a/_episodes/06-gh-pages.md
+++ b/_episodes/06-gh-pages.md
@@ -50,7 +50,7 @@ material is hosted.
 > ## Real-life examples
 >
 > - Research Software Hour
->   - Source: <https://raw.githubusercontent.com/ResearchSoftwareHour/researchsoftwarehour.github.io/master/about.md>
+>   - Source: <https://raw.githubusercontent.com/ResearchSoftwareHour/researchsoftwarehour.github.io/main/content/about.md>
 >   - Result: <https://researchsoftwarehour.github.io/about/>
 > - This lesson
 >   - Source: <https://raw.githubusercontent.com/coderefinery/documentation/gh-pages/_episodes/06-gh-pages.md>


### PR DESCRIPTION
Fixes #150 

Corrected the first URL for Real-life examples of Research Software Hour (RSH) page:

Correct URL:
https://raw.githubusercontent.com/ResearchSoftwareHour/researchsoftwarehour.github.io/main/content/about.md


Old and Incorrect URL:
https://raw.githubusercontent.com/ResearchSoftwareHour/researchsoftwarehour.github.io/master/about.md