### PR TITLE
link to build/preview documentation; closes #158

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 ## Credit and license
 
 - https://coderefinery.github.io/documentation/license/
+
+
+## How to preview the lesson locally
+
+- https://coderefinery.github.io/sphinx-lesson/contributing-to-a-lesson/#build-and-test-locally


### PR DESCRIPTION
Closes issue which asked for Jekyll preview instructions but they are now not needed here anymore.