### PR TITLE
Fix MyST syntax in sphinx page

### DIFF
--- a/content/sphinx.md
+++ b/content/sphinx.md
@@ -335,10 +335,13 @@ This is an inline equation embedded {math}`a^2 + b^2 = c^2` in text.
 
 An equation:
 
+~~~
 {math}`a^2 + b^2 = c^2`
+~~~
 
 or:
-.. math::
+~~~
+```{math}
 a^2 + b^2 = c^2
 ```
 ~~~


### PR DESCRIPTION
Show the syntax for displaying an equation, instead of the equation itself.
Also fix left-over rst.