### PR TITLE
Fix some MyST issues

### DIFF
--- a/content/sphinx.md
+++ b/content/sphinx.md
@@ -133,9 +133,28 @@ Indices and tables
   :maxdepth: 2
   :caption: Contents:
 
-  feature-a.rst
+  feature-a.md
 ```
 A common gotcha with directives is that **the first line of the content must be indented to the same level as the options (i.e., :maxdepth)**.
+
+We now need to tell Sphinx to use markdown files. To do this, we open
+`conf.py` and replace the lines
+
+```python
+extensions = [
+]
+```
+
+with
+
+```python
+extensions = ['myst_parser']
+
+source_suffix = ['.rst', '.md']
+```
+
+The first part tells Sphinx to use and extension to parse Markdown files
+and the second part tells it to actually look for those files.
 
 Let's create the file `feature-a.md` which `index.rst` refers to:
 
@@ -286,10 +305,10 @@ The following is a code block:
 ~~~
 - You could include the contents of an external file using `{include}` directive, as follows:
 
-```md
+~~~md
  ```{include} ../README.md
  ```
-```
+~~~
 
 <!--
 Note, that this will not resolve e.g. image paths within README.md, use experimental feature `{literalinclude}` instead:
@@ -329,8 +348,6 @@ the list of extensions in `conf.py`:
 extensions = ['sphinx.ext.mathjax']
 ```
 
-**Add here: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#syntax-amsmath**
-
 The following shows how to inline mathematics within a text:
 
 ```md
@@ -338,17 +355,13 @@ This is an inline equation embedded {math}`a^2 + b^2 = c^2` in text.
 ```
 
 An equation:
-
-~~~
-{math}`a^2 + b^2 = c^2`
-~~~
-
-or:
 ~~~
 ```{math}
 a^2 + b^2 = c^2
 ```
 ~~~
+
+For more math syntax, check [the MyST documentation](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#syntax-amsmath).
 
 ````
 

--- a/content/sphinx.md
+++ b/content/sphinx.md
@@ -291,12 +291,16 @@ The following is a code block:
  ```
 ```
 
+<!--
 Note, that this will not resolve e.g. image paths within README.md, use experimental feature `{literalinclude}` instead:
 
-```md
-{literalinclude} ../README.md
-:language: md
-```
+~~~md
+ ```
+ {literalinclude} ../README.md
+ :language: md
+ ```
+~~~
+-->
 
 - It is possible to combine `{include}` with code highlighting, line numbering, and even line highlighting.
 - We can also use jupyter notebooks (*.ipynb) with sphinx. It requires `nbsphinx` extension to be installed. See [nbsphinx documentation](http://nbsphinx.readthedocs.io/en/latest/) for more information

--- a/content/tools.md
+++ b/content/tools.md
@@ -70,8 +70,9 @@ There is more: images,            There is more: images,
 tables, links, ...                tables, links, ...
 ```
 
-- We will use Markdown in the {ref}`sphinx` episode
-  and the {ref}`gh-pages` example
+- We will use [MyST](https://myst-parser.readthedocs.io/en/latest/)
+  flavored Markdown in the {ref}`sphinx` episode and the
+  {ref}`gh-pages` example
 
 Experiment with Markdown:
 - [Learn Markdown in 60 seconds](http://commonmark.org/help/)

--- a/content/tools.md
+++ b/content/tools.md
@@ -70,8 +70,8 @@ There is more: images,            There is more: images,
 tables, links, ...                tables, links, ...
 ```
 
-- We will use RST in the {ref}`sphinx` episode
-  and Markdown in the {ref}`gh-pages` example
+- We will use Markdown in the {ref}`sphinx` episode
+  and the {ref}`gh-pages` example
 
 Experiment with Markdown:
 - [Learn Markdown in 60 seconds](http://commonmark.org/help/)


### PR DESCRIPTION
Add changes to conf.py and fix some nested quotes.

I commented out the literalquote-part. It always seems to appear in a block, and does not include the markdown directly.

Review:
 * basic sanity check
 * what about the literalquote part?