### PR TITLE
Remove mention of sphinx servers

### DIFF
--- a/content/gh_workflow.md
+++ b/content/gh_workflow.md
@@ -141,13 +141,9 @@ repository.
 [Read the Docs](https://readthedocs.org) is the most common alternative to
 hosting in GitHub Pages.
 
-You can host your own Sphinx server. If you want to know more about it, look at:
-- [https://docs.readthedocs.io/en/latest/install.html](https://docs.readthedocs.io/en/latest/install.html)
-- [https://pypi.org/project/sphinx-autobuild/](https://pypi.org/project/sphinx-autobuild/)
-- [https://pypi.org/project/sphinx-server/](https://pypi.org/project/sphinx-server/)
-
-You can also build Sphinx using GitHub Actions or GitLab CI
-([example workflow for building this lesson](https://github.com/coderefinery/documentation/blob/main/.github/workflows/sphinx.yml)).
+Sphinx simply builds HTML files, and you can host them anywhere, for
+example your university's web space or own web server.  This is the
+whole point of **static site generators**.
 
 
 ## Migrating your own documentation to Sphinx

--- a/content/sphinx.md
+++ b/content/sphinx.md
@@ -382,6 +382,10 @@ For more math syntax (separate to what is above, not needed for this exercise), 
 
 ````
 
+[sphinx-autobuild](https://pypi.org/project/sphinx-autobuild/)
+provides a local web server that will automatically refresh your view
+every time you save a file - which makes writing and testing much easier.
+
 ---
 
 ### Where to find more


### PR DESCRIPTION
- Few people will want to host a readthedocs server, or even an own
  sphinx-server.  We don't need to mention those in a first lesson.
- Instead mention the power of static site generators.
- Move sphinx-autobuild to the sphinx lesson, since this is important
  and more relevant there.
- Review: consider the above points
