### PR TITLE
content/gh_workflow: Fix links to gh-pages deployments

### DIFF
--- a/content/gh_workflow.md
+++ b/content/gh_workflow.md
@@ -106,14 +106,13 @@ Replace `<myuser>` with your GitHub username.
 - Go to `https://github.com/<myuser>/word-count/settings/pages`
 - In the "Source" section, choose "gh-pages" in the dropdown menu and click
   save
-- Your documentation will appear at
-  `https://github.com/<myuser>/word-count/settings/pages`
+- (You should be able to verify the pages deployment in the Actions list)
 
 
 **Verify the result**
 
 That's it! Your site should now be live on
-`https://<myuser>.github.com/word-count/settings/pages` (replace username).
+`https://<myuser>.github.io/word-count/` (replace username).
 
 **Verify refreshing the documentation**
 


### PR DESCRIPTION
- Fix the links (some were github.com instead of github.io, and more
  problems)
- De-duplicate the "check the deployment" link (review: verify that
  this is the intention, I don't think we need the same link twice -
  or was that not the intention?)
- Review: general check.
