### PR TITLE
Remove "lesson" from lesson name

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = "Code documentation lesson"
+project = "Code documentation"
 copyright = "2021, CodeRefinery team"
 author = "CodeRefinery team"
 github_user = "coderefinery"

--- a/content/index.rst
+++ b/content/index.rst
@@ -1,5 +1,5 @@
-Code documentation lesson
-=========================
+Code documentation
+==================
 
 In this lesson we will discuss different solutions for implementing and
 deploying code documentation.


### PR DESCRIPTION
- I think title should be about the topic, not describing itself.
- Random check of other lessons show this is consistent
- Review: consider first point above
