### PR TITLE
Add instructions to generate Sphinx autodoc 

### DIFF
--- a/content/sphinx.md
+++ b/content/sphinx.md
@@ -397,6 +397,43 @@ For more math syntax (separate to what is above, not needed for this exercise), 
 
 ````
 
+### Exercise: Sphinx autodoc
+
+````{exercise} (optional) Sphinx-4: Auto-generating documentation from docstrings.
+
+1. In the the folder `doc-example` add a file `API.rst` with the following contents:
+
+```rst
+Python API
+==========
+
+my-module
++++++++++
+
+.. automodule:: my-module
+   :members:
+```
+
+2. In the file `conf.py` add:
+
+```python
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../"))
+
+# in extensions add "sphinx.ext.autodoc"
+extensions = ['myst_parser', "sphinx.ext.autodoc"]
+```
+
+~~~{callout}
+If your working tree is different you might have to adapt the path passed in `sys.path.insert(0, os.path.abspath("../"))` such that it points to the python module.
+~~~
+
+3. In `index.rst` add `API` below `feature-a.md`. This will add a section with the contents of `API.rst`.
+
+````
+
 [sphinx-autobuild](https://pypi.org/project/sphinx-autobuild/)
 provides a local web server that will automatically refresh your view
 every time you save a file - which makes writing and testing much easier.

--- a/content/sphinx.md
+++ b/content/sphinx.md
@@ -401,7 +401,22 @@ For more math syntax (separate to what is above, not needed for this exercise), 
 
 ````{exercise} (optional) Sphinx-4: Auto-generating documentation from docstrings.
 
-1. In the the folder `doc-example` add a file `API.rst` with the following contents:
+1. Write some docstrings in functions and/or class definitions of `my-module` python module. You can use sphinx syntax as follows:
+
+```python
+def mean_temperature(data):
+    """
+    Get the mean temperature
+
+    :param data (pandas.DataFrame): A pandas dataframe with air temperature measurements.
+
+    :returns: The mean air temperature (float)
+    """
+    temperatures = data['Air temperature (degC)']
+    return float(sum(temperatures)/len(temperatures))
+```
+
+2. In the the folder `doc-example` add a file `API.rst` with the following contents:
 
 ```rst
 Python API
@@ -414,7 +429,7 @@ my-module
    :members:
 ```
 
-2. In the file `conf.py` add:
+3. In the file `conf.py` add:
 
 ```python
 import os
@@ -430,7 +445,13 @@ extensions = ['myst_parser', "sphinx.ext.autodoc"]
 If your working tree is different you might have to adapt the path passed in `sys.path.insert(0, os.path.abspath("../"))` such that it points to the python module.
 ~~~
 
-3. In `index.rst` add `API` below `feature-a.md`. This will add a section with the contents of `API.rst`.
+4. In `index.rst` add `API` below `feature-a.md`. This will add a section with the contents of `API.rst`.
+5. Re-build the documentation and check the `API` section and how the docstrings get rendered.
+
+```bash
+cd doc-example
+sphinx-build . _build
+```
 
 ````
 


### PR DESCRIPTION
This PR is related to issue #267. 
In this PR I added the instructions of a 4th optional exercise in the [Sphinx and Markdown](https://coderefinery.github.io/documentation/sphinx/) section in which a section of the documentation will be automatically generated from the docstrings.

I would also like to tag @bvreede and @OleMussmann who were teaching with me the coderefinery where we tried out this optional exercise. Could you please review these changes too? 