### PR TITLE
updated action versions for setup-python and checkout

### DIFF
--- a/content/gh_workflow.md
+++ b/content/gh_workflow.md
@@ -58,8 +58,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
           pip install sphinx sphinx_rtd_theme myst_parser


### PR DESCRIPTION
Just making use of this example and I noticed the action versions are a bit behind the current versions.

thought it might be worth updating them.

thanks for making the repo