### PR TITLE
sphinx: update for sphinx-quickstart version 8.2.3

### DIFF
--- a/content/sphinx.md
+++ b/content/sphinx.md
@@ -122,15 +122,8 @@ Welcome to myproject's documentation!
    :caption: Contents:
 
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
 ```
 
-- We will not use the `Indices and tables` section now, so remove it and everything below.
 - The top four lines, starting with `..`, are a comment.
 - The next lines are the table of contents. We can add content below:
 


### PR DESCRIPTION
Indices and Tables section is not created any more, no need to remove it.