### PR TITLE
Bioschemas lesson metadata integrated to lesson.html 

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install sphinx-bioschemas
 
         # Debug
       - name: Debugging information

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install sphinx-bioschemas
 
         # Debug
       - name: Debugging information

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _build/
 venv/
 .*.sw?
+*.DS_Store

--- a/bioschemas.yml
+++ b/bioschemas.yml
@@ -1,0 +1,79 @@
+{
+    "@context": "https://schema.org/",
+    "@type": "LearningResource",
+    "@id": "https://coderefinery.github.io/documentation/",
+    "description": "The lesson 'How to document your research software' gives an overview of the different ways how a code project can be documented: from small projects to larger projects. Markdown and Sphinx are central tools in this lesson.",
+    "keywords": "Documentation, Sphinx",
+    "name": "How to document your research software",
+    #"about": "",
+    #"audience": "",
+    "author": [
+        {
+            "@type": "Organization",
+            "name": "CodeRefinery"
+        },
+        {
+            "@type": "Person",
+            "name": "Radovan Bast"
+        },
+        {
+            "@type": "Person",
+            "name": "Richard Darst"
+        },
+        {
+            "@type": "Person",
+            "name": "Bj\u00f8rn Lindi"
+        },
+        {
+            "@type": "Person",
+            "name": "Stefan Negru"
+        },
+        {
+            "@type": "Person",
+            "name": "Luisa Orozco"
+        },
+        {
+            "@type": "Person",
+            "name": "Jarno Rantaharju"
+        },
+        {
+            "@type": "Person",
+            "name": "Annajiat Alim Rasel"
+        },
+        {
+            "@type": "Person",
+            "name": "Sabry Razick"
+        },
+        {
+            "@type": "Person",
+            "name": "Sven van der Burg"
+        },
+        {
+            "@type": "Person",
+            "name": "Marijn van Vliet"
+        },
+        {
+            "@type": "Person",
+            "name": "Kjartan Thor Wikfeldt"
+        },
+        {
+            "@type": "Person",
+            "name": "Samantha Wittke"
+        },
+        {
+            "@type": "Person",
+            "name": "Michele Mesiti"
+        }
+    ],
+    # "competencyRequired": "",
+    "educationalLevel": "Beginner",
+    "identifier": "https://doi.org/10.5281/zenodo.8280234",
+    "inLanguage": "en-UK",
+    #"learningResourceType": "",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "teaches": "Understand the importance of writing code documentation together with the source code, Know what makes a good documentation, Learn what tools can be used for writing documentation, Be able to motivate a balanced decision: sometimes READMEs are absolutely enough",
+    "url": "https://coderefinery.github.io/documentation/",
+    # "accessibilitySummary": "",
+    "isPartOf": "CodeRefinery workshop",
+    "version": "2023-08-24"
+}

--- a/bioschemas.yml
+++ b/bioschemas.yml
@@ -5,8 +5,6 @@
     "description": "The lesson 'How to document your research software' gives an overview of the different ways how a code project can be documented: from small projects to larger projects. Markdown and Sphinx are central tools in this lesson.",
     "keywords": "Documentation, Sphinx",
     "name": "How to document your research software",
-    #"about": "",
-    #"audience": "",
     "author": [
         {
             "@type": "Organization",
@@ -65,15 +63,12 @@
             "name": "Michele Mesiti"
         }
     ],
-    # "competencyRequired": "",
     "educationalLevel": "Beginner",
     "identifier": "https://doi.org/10.5281/zenodo.8280234",
     "inLanguage": "en-UK",
-    #"learningResourceType": "",
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "teaches": "Understand the importance of writing code documentation together with the source code, Know what makes a good documentation, Learn what tools can be used for writing documentation, Be able to motivate a balanced decision: sometimes READMEs are absolutely enough",
     "url": "https://coderefinery.github.io/documentation/",
-    # "accessibilitySummary": "",
     "isPartOf": "CodeRefinery workshop",
     "version": "2023-08-24"
 }

--- a/content/conf.py
+++ b/content/conf.py
@@ -39,6 +39,7 @@ extensions = [
     # remove once sphinx_rtd_theme updated for contrast and accessibility:
     "sphinx_rtd_theme_ext_color_contrast",
     "sphinx_coderefinery_branding",
+    "sphinx_bioschemas",
 ]
 
 # Settings for myst_nb:
@@ -75,6 +76,8 @@ exclude_patterns = [
     "*venv*",
 ]
 
+# Add bioschemas
+bioschemas = ["bioschemas.yaml"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/content/conf.py
+++ b/content/conf.py
@@ -77,7 +77,7 @@ exclude_patterns = [
 ]
 
 # Add bioschemas
-bioschemas = ["bioschemas.yaml"]
+bioschemas = ["bioschemas.yml"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/content/index.md
+++ b/content/index.md
@@ -90,7 +90,6 @@ gh-pages.md
 Shell crash course <https://youtu.be/xbTTDLA3txI>
 exercises.md
 guide.md
-license.md
 ```
 
 ```{toctree}
@@ -99,5 +98,5 @@ license.md
 
 All lessons <https://coderefinery.org/lessons/core/>
 CodeRefinery <https://coderefinery.org/>
-Reusing <https://coderefinery.org/lessons/reusing/>
+reusing.md
 ```

--- a/content/reusing.md
+++ b/content/reusing.md
@@ -3,6 +3,25 @@
 This lesson material is free to reuse, adapt, and cite. This page collects
 everything you need to do so.
 
+## How to cite this lesson
+
+If you use this lesson material, please cite it using this DOI:
+
+<https://doi.org/10.5281/zenodo.8280234>
+
+The machine-readable citation record is kept in
+[`CITATION.cff`](https://raw.githubusercontent.com/coderefinery/documentation/refs/heads/main/CITATION.cff)
+at the root of this lesson's repository, which lists the full set of
+contributing authors and stays up to date as the lesson evolves.
+
+## Structured metadata
+
+This lesson also publishes its metadata as machine-readable
+[Bioschemas](https://bioschemas.org/) / [schema.org](https://schema.org/)
+structured data, embedded as JSON-LD on every page of this site. You can
+inspect the source directly in
+[`bioschemas.yml`](https://raw.githubusercontent.com/coderefinery/documentation/refs/heads/main/bioschemas.yml).
+
 ## License
 
 ### Website template
@@ -45,21 +64,3 @@ With the understanding that:
   rights such as publicity, privacy, or moral rights may limit how
   you use the material.
 
-## How to cite this lesson
-
-If you use this lesson material, please cite it using this DOI:
-
-<https://doi.org/10.5281/zenodo.8280234>
-
-The machine-readable citation record is kept in
-[`CITATION.cff`](https://raw.githubusercontent.com/coderefinery/documentation/refs/heads/main/CITATION.cff)
-at the root of this lesson's repository, which lists the full set of
-contributing authors and stays up to date as the lesson evolves.
-
-## Structured metadata
-
-This lesson also publishes its metadata as machine-readable
-[Bioschemas](https://bioschemas.org/) / [schema.org](https://schema.org/)
-structured data, embedded as JSON-LD on every page of this site. You can
-inspect the source directly in
-[`bioschemas.yml`](https://raw.githubusercontent.com/coderefinery/documentation/refs/heads/main/bioschemas.yml).

--- a/content/reusing.md
+++ b/content/reusing.md
@@ -47,12 +47,11 @@ With the understanding that:
 
 ## How to cite this lesson
 
-If you use this lesson material, please cite it using the metadata below:
+If you use this lesson material, please cite it using this DOI:
 
-> CodeRefinery community (2023). "How to document your research software"
-> (Version 2023-08-24) [Data set]. Zenodo. <https://doi.org/10.5281/zenodo.8280234>
+<https://doi.org/10.5281/zenodo.8280234>
 
-The authoritative, machine-readable citation record is kept in
+The machine-readable citation record is kept in
 [`CITATION.cff`](https://raw.githubusercontent.com/coderefinery/documentation/refs/heads/main/CITATION.cff)
 at the root of this lesson's repository, which lists the full set of
 contributing authors and stays up to date as the lesson evolves.

--- a/content/reusing.md
+++ b/content/reusing.md
@@ -1,15 +1,16 @@
-# Credit and license
+# Reusing
 
-This material is provided by CodeRefinery under the licenses stated below.
+This lesson material is free to reuse, adapt, and cite. This page collects
+everything you need to do so.
 
+## License
 
-## Website template
+### Website template
 
 The website template is maintained by [CodeRefinery](https://coderefinery.org/)
 and rendered with [sphinx-lesson: structured lessons with Sphinx](https://coderefinery.github.io/sphinx-lesson/).
 
-
-## Instructional material
+### Instructional material
 
 All CodeRefinery instructional material is made available under the
 [Creative Commons Attribution license (CC-BY-4.0)](https://creativecommons.org/licenses/by/4.0/).
@@ -43,3 +44,23 @@ With the understanding that:
   permissions necessary for your intended use. For example, other
   rights such as publicity, privacy, or moral rights may limit how
   you use the material.
+
+## How to cite this lesson
+
+If you use this lesson material, please cite it using the metadata below:
+
+> CodeRefinery community (2023). "How to document your research software"
+> (Version 2023-08-24) [Data set]. Zenodo. <https://doi.org/10.5281/zenodo.8280234>
+
+The authoritative, machine-readable citation record is kept in
+[`CITATION.cff`](https://raw.githubusercontent.com/coderefinery/documentation/refs/heads/main/CITATION.cff)
+at the root of this lesson's repository, which lists the full set of
+contributing authors and stays up to date as the lesson evolves.
+
+## Structured metadata
+
+This lesson also publishes its metadata as machine-readable
+[Bioschemas](https://bioschemas.org/) / [schema.org](https://schema.org/)
+structured data, embedded as JSON-LD on every page of this site. You can
+inspect the source directly in
+[`bioschemas.yml`](https://raw.githubusercontent.com/coderefinery/documentation/refs/heads/main/bioschemas.yml).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx-copybutton==0.5.2
 sphinx-lesson
 sphinx_rtd_theme_ext_color_contrast
 https://github.com/coderefinery/sphinx-coderefinery-branding/archive/master.zip
+sphinx-bioschemas


### PR DESCRIPTION
- adds sphinx-bioschemas extension to sphinx workflow
- adds bioshemas.yml with lesson metadata from CITATION.cff ([script exists](https://gist.github.com/samumantha/a8367a0541dadc91c18391329e8b873f) but not added; could become another action later to only maintain one metadata file) and lesson itself
- combine license and reuse info into reuse.md under "about" instead of link to webpage; this reusing page also links to raw citation.cff and Bioschemas.yml file.  

I have tested the general workflow and build locally. Slight uncertainty if it's in the right place in sphinx.yml. Please check :) 

This is the test lesson for this implementation. If it looks good we can implement for other lessons too. 

